### PR TITLE
feat: Implement OpenQASM 3.0 formatter with comment extraction and formatting logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,153 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "borsh"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "countme"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
+
+[[package]]
+name = "cov-mark"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90863d8442510cddf7f46618c4f92413774635771a3e80830c8b30d183420b14"
+
+[[package]]
+name = "drop_bomb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,18 +157,114 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oq3_lexer"
+version = "0.7.0"
+source = "git+https://github.com/Qiskit/openqasm3_parser?branch=main#3eac9970f37baf6d030a3a185b9421cca3cf0a59"
+dependencies = [
+ "unicode-properties",
+ "unicode-xid",
+]
+
+[[package]]
+name = "oq3_parser"
+version = "0.7.0"
+source = "git+https://github.com/Qiskit/openqasm3_parser?branch=main#3eac9970f37baf6d030a3a185b9421cca3cf0a59"
+dependencies = [
+ "drop_bomb",
+ "oq3_lexer",
+ "ra_ap_limit",
+]
+
+[[package]]
+name = "oq3_syntax"
+version = "0.7.0"
+source = "git+https://github.com/Qiskit/openqasm3_parser?branch=main#3eac9970f37baf6d030a3a185b9421cca3cf0a59"
+dependencies = [
+ "cov-mark",
+ "either",
+ "indexmap",
+ "itertools",
+ "once_cell",
+ "oq3_lexer",
+ "oq3_parser",
+ "proc-macro2",
+ "quote",
+ "rowan",
+ "rustc-hash 2.1.1",
+ "rustversion",
+ "smol_str",
+ "triomphe",
+ "ungrammar",
+ "xshell",
 ]
 
 [[package]]
@@ -37,6 +280,9 @@ dependencies = [
 name = "qasmfmt"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
+ "clap",
+ "oq3_syntax",
  "serde",
  "thiserror",
  "toml",
@@ -50,6 +296,43 @@ checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "ra_ap_limit"
+version = "0.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d33f2d8eda04460315de38992e3681dd799c27e712788a7aeee9909bc1c0f5"
+
+[[package]]
+name = "rowan"
+version = "0.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a58fa8a7ccff2aec4f39cc45bf5f985cec7125ab271cf681c279fd00192b49"
+dependencies = [
+ "countme",
+ "hashbrown 0.14.5",
+ "memoffset",
+ "rustc-hash 1.1.0",
+ "text-size",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
@@ -83,12 +366,28 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
- "serde_core",
+ "serde",
 ]
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -100,6 +399,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "text-size"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
@@ -123,42 +428,56 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.11+spec-1.1.0"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
- "indexmap",
- "serde_core",
+ "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+name = "toml_edit"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+name = "toml_write"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+
+[[package]]
+name = "ungrammar"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e5df347f0bf3ec1d670aad6ca5c6a1859cd9ea61d2113125794654ccced68f"
 
 [[package]]
 name = "unicode-ident"
@@ -167,7 +486,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "xshell"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7290c623014758632efe00737145b6867b66292c42167f2ec381eb566a373d"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ac00cd3f8ec9c1d33fb3e7958a82df6989c42d747bd326c822b1d625283547"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,11 @@ categories = ["development-tools", "command-line-utilities"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2.0.17"
-toml = "0.9.11"
+toml = "0.8"
+oq3_syntax = { git = "https://github.com/Qiskit/openqasm3_parser", branch = "main" }
+clap = { version = "4.5", features = ["derive"] }
+anyhow = "1.0"
+
+[[bin]]
+name = "qasmfmt"
+path = "src/main.rs"

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1,0 +1,131 @@
+//! Comment extraction
+
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentStyle {
+    Line,
+    Block,
+}
+
+#[derive(Debug, Clone)]
+pub struct Comment {
+    pub style: CommentStyle,
+    pub content: String,
+    pub line: usize,
+    pub column: usize,
+}
+
+pub type CommentMap = BTreeMap<usize, Vec<Comment>>;
+
+pub fn extract_comments(source: &str) -> CommentMap {
+    let mut comments = CommentMap::new();
+    let mut chars = source.char_indices().peekable();
+    let mut line = 0;
+    let mut line_start = 0;
+    let mut in_string = false;
+
+    while let Some((i, c)) = chars.next() {
+        if c == '\n' {
+            line += 1;
+            line_start = i + 1;
+            continue;
+        }
+
+        if c == '"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string {
+            continue;
+        }
+
+        if c == '/' {
+            if let Some(&(_, next)) = chars.peek() {
+                if next == '/' {
+                    chars.next();
+                    let start = i;
+                    let mut end = i + 2;
+
+                    while let Some(&(j, ch)) = chars.peek() {
+                        if ch == '\n' {
+                            break;
+                        }
+                        end = j + ch.len_utf8();
+                        chars.next();
+                    }
+
+                    comments.entry(line).or_default().push(Comment {
+                        style: CommentStyle::Line,
+                        content: source[start..end].to_string(),
+                        line,
+                        column: i - line_start,
+                    });
+                } else if next == '*' {
+                    chars.next();
+                    let start = i;
+                    let start_line = line;
+                    let mut end = i + 2;
+
+                    while let Some((j, ch)) = chars.next() {
+                        if ch == '\n' {
+                            line += 1;
+                            line_start = j + 1;
+                        }
+                        if ch == '*' {
+                            if let Some(&(_, '/')) = chars.peek() {
+                                chars.next();
+                                end = j + 2;
+                                break;
+                            }
+                        }
+                        end = j + ch.len_utf8();
+                    }
+
+                    comments.entry(start_line).or_default().push(Comment {
+                        style: CommentStyle::Block,
+                        content: source[start..end].to_string(),
+                        line: start_line,
+                        column: i - (if start_line == 0 { 0 } else { line_start }),
+                    });
+                }
+            }
+        }
+    }
+
+    comments
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_line_comment() {
+        let source = "qubit q; // comment\n";
+        let comments = extract_comments(source);
+
+        assert_eq!(comments.len(), 1);
+        let line_comments = &comments[&0];
+        assert_eq!(line_comments.len(), 1);
+        assert_eq!(line_comments[0].style, CommentStyle::Line);
+        assert_eq!(line_comments[0].content, "// comment");
+    }
+
+    #[test]
+    fn test_block_comment() {
+        let source = "/* block */\nqubit q;";
+        let comments = extract_comments(source);
+
+        assert_eq!(comments.len(), 1);
+        let line_comments = &comments[&0];
+        assert_eq!(line_comments[0].style, CommentStyle::Block);
+    }
+
+    #[test]
+    fn test_comment_in_string() {
+        let source = r#"include "// not comment";"#;
+        let comments = extract_comments(source);
+        assert!(comments.is_empty());
+    }
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,408 @@
+//! Formatting logic
+
+use oq3_syntax::SourceFile;
+use oq3_syntax::ast::{self, AstNode, HasArgList, HasName};
+
+use crate::config::FormatConfig;
+use crate::error::FormatError;
+use crate::ir::{Doc, join};
+
+pub struct FormatContext<'a> {
+    pub config: &'a FormatConfig,
+    pub source: &'a str,
+}
+
+impl<'a> FormatContext<'a> {
+    pub fn new(config: &'a FormatConfig, source: &'a str) -> Self {
+        Self { config, source }
+    }
+}
+
+pub fn format_source(source: &str, config: &FormatConfig) -> Result<String, FormatError> {
+    if source.trim().is_empty() {
+        return Err(FormatError::EmptyInput);
+    }
+
+    let parse_result = SourceFile::parse(source);
+    let source_file = parse_result.tree();
+
+    let errors = parse_result.errors();
+    if !errors.is_empty() {
+        let first = &errors[0];
+        return Err(FormatError::Syntax(format!("{:?}", first)));
+    }
+
+    let ctx = FormatContext::new(config, source);
+    let doc = format_file(&ctx, &source_file);
+    let result = crate::printer::print(&doc, config);
+
+    Ok(result)
+}
+
+fn format_file(ctx: &FormatContext, file: &ast::SourceFile) -> Doc {
+    let mut docs = Vec::new();
+
+    for stmt in file.statements() {
+        docs.push(format_stmt(ctx, stmt));
+        docs.push(Doc::hardline());
+    }
+
+    Doc::concat(docs)
+}
+
+fn format_stmt(ctx: &FormatContext, stmt: ast::Stmt) -> Doc {
+    match stmt {
+        ast::Stmt::VersionString(v) => format_version(v),
+        ast::Stmt::Include(i) => format_include(i),
+        ast::Stmt::QuantumDeclarationStatement(q) => format_quantum_decl(q),
+        ast::Stmt::ClassicalDeclarationStatement(c) => format_classical_decl(c),
+        ast::Stmt::Gate(g) => format_gate_def(ctx, g),
+        ast::Stmt::ExprStmt(e) => format_expr_stmt(e),
+        ast::Stmt::Measure(m) => format_measure_stmt(m),
+        ast::Stmt::AssignmentStmt(a) => format_assignment(a),
+        ast::Stmt::Reset(r) => format_reset(r),
+        ast::Stmt::Barrier(b) => format_barrier(b),
+        _ => Doc::text(stmt.syntax().text().to_string().trim()),
+    }
+}
+
+fn format_version(v: ast::VersionString) -> Doc {
+    // TODO: oq3_syntax's VersionString::version() always returns None
+    // because lexer treats "OPENQASM 3.0" as a single token.
+    // See: https://github.com/Qiskit/openqasm3_parser/issues/118
+    let version_str = extract_version_number(&v);
+    Doc::concat(vec![
+        Doc::text("OPENQASM "),
+        Doc::text(version_str),
+        Doc::text(";"),
+    ])
+}
+
+/// Workaround: extract version from VERSION_STRING token since version() doesn't work.
+fn extract_version_number(v: &ast::VersionString) -> String {
+    use oq3_syntax::SyntaxKind::VERSION_STRING;
+
+    for token in v.syntax().children_with_tokens() {
+        if let Some(tok) = token.as_token() {
+            if tok.kind() == VERSION_STRING {
+                return tok
+                    .text()
+                    .strip_prefix("OPENQASM")
+                    .map(|s| s.trim().to_string())
+                    .unwrap_or_default();
+            }
+        }
+    }
+    String::new()
+}
+
+fn format_include(i: ast::Include) -> Doc {
+    let file_path = i
+        .file()
+        .map(|f| f.syntax().text().to_string())
+        .unwrap_or_default();
+    Doc::concat(vec![
+        Doc::text("include "),
+        Doc::text(file_path),
+        Doc::text(";"),
+    ])
+}
+
+fn format_quantum_decl(q: ast::QuantumDeclarationStatement) -> Doc {
+    let mut parts = vec![Doc::text("qubit")];
+
+    if let Some(qubit_type) = q.qubit_type() {
+        if let Some(designator) = qubit_type.designator() {
+            if let Some(expr) = designator.expr() {
+                parts.push(Doc::text("["));
+                parts.push(format_expr(expr));
+                parts.push(Doc::text("]"));
+            }
+        }
+    }
+
+    parts.push(Doc::space());
+    if let Some(name) = q.name() {
+        parts.push(Doc::text(name.to_string()));
+    }
+    parts.push(Doc::text(";"));
+
+    Doc::concat(parts)
+}
+
+fn format_expr_stmt(e: ast::ExprStmt) -> Doc {
+    let mut parts = vec![];
+    if let Some(expr) = e.expr() {
+        parts.push(format_expr(expr));
+    }
+    parts.push(Doc::text(";"));
+    Doc::concat(parts)
+}
+
+fn format_expr(expr: ast::Expr) -> Doc {
+    match expr {
+        ast::Expr::Identifier(id) => {
+            Doc::text(id.ident_token().map(|t| t.to_string()).unwrap_or_default())
+        }
+        ast::Expr::Literal(lit) => Doc::text(lit.syntax().text().to_string()),
+        ast::Expr::IndexedIdentifier(idx) => format_indexed_identifier(&idx),
+        ast::Expr::GateCallExpr(g) => format_gate_call(g),
+        ast::Expr::MeasureExpression(m) => format_measure_expr(m),
+        ast::Expr::ParenExpr(paren) => {
+            let mut parts = vec![Doc::text("(")];
+            if let Some(inner) = paren.expr() {
+                parts.push(format_expr(inner));
+            }
+            parts.push(Doc::text(")"));
+            Doc::concat(parts)
+        }
+        _ => Doc::text(expr.syntax().text().to_string()),
+    }
+}
+
+fn format_indexed_identifier(idx: &ast::IndexedIdentifier) -> Doc {
+    let mut parts = vec![];
+
+    // TODO: oq3_syntax's IndexedIdentifier::name() always returns None
+    // because parser creates IDENTIFIER node instead of NAME node.
+    let name = extract_indexed_identifier_name(idx);
+    if !name.is_empty() {
+        parts.push(Doc::text(name));
+    }
+
+    for index in idx.index_operators() {
+        parts.push(Doc::text("["));
+        let inner_text = index.syntax().text().to_string();
+        let inner = inner_text
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .trim();
+        parts.push(Doc::text(inner));
+        parts.push(Doc::text("]"));
+    }
+    Doc::concat(parts)
+}
+
+/// Workaround: extract name from syntax children since name() doesn't work.
+fn extract_indexed_identifier_name(idx: &ast::IndexedIdentifier) -> String {
+    use oq3_syntax::SyntaxKind::IDENTIFIER;
+
+    for child in idx.syntax().children() {
+        if child.kind() == IDENTIFIER {
+            return child.text().to_string();
+        }
+    }
+    String::new()
+}
+
+fn format_gate_call(g: ast::GateCallExpr) -> Doc {
+    let mut parts = vec![];
+
+    // TODO: oq3_syntax's GateCallExpr::name() always returns None
+    // because parser creates IDENTIFIER node instead of NAME node.
+    let gate_name = extract_gate_call_name(&g);
+    if !gate_name.is_empty() {
+        parts.push(Doc::text(gate_name));
+    }
+
+    if let Some(params) = g.arg_list() {
+        let params_text = params.syntax().text().to_string();
+        if !params_text.trim().is_empty() {
+            parts.push(Doc::text(params_text));
+        }
+    }
+
+    if let Some(qubits) = g.qubit_list() {
+        let qubit_operands: Vec<_> = qubits.gate_operands().collect();
+        if !qubit_operands.is_empty() {
+            parts.push(Doc::space());
+            let qubit_docs: Vec<Doc> = qubit_operands
+                .into_iter()
+                .map(format_gate_operand)
+                .collect();
+            parts.push(join(qubit_docs, Doc::text(", ")));
+        }
+    }
+
+    Doc::concat(parts)
+}
+
+/// Workaround: extract gate name from syntax children since name() doesn't work.
+fn extract_gate_call_name(g: &ast::GateCallExpr) -> String {
+    use oq3_syntax::SyntaxKind::IDENTIFIER;
+
+    for child in g.syntax().children() {
+        if child.kind() == IDENTIFIER {
+            return child.text().to_string();
+        }
+    }
+    String::new()
+}
+
+fn format_gate_operand(op: ast::GateOperand) -> Doc {
+    match op {
+        ast::GateOperand::Identifier(id) => {
+            Doc::text(id.ident_token().map(|t| t.to_string()).unwrap_or_default())
+        }
+        ast::GateOperand::IndexedIdentifier(idx) => format_indexed_identifier(&idx),
+        ast::GateOperand::HardwareQubit(hw) => Doc::text(hw.syntax().text().to_string()),
+    }
+}
+
+fn format_gate_def(ctx: &FormatContext, g: ast::Gate) -> Doc {
+    let mut parts = vec![];
+
+    parts.push(Doc::text("gate "));
+
+    if let Some(name) = g.name() {
+        parts.push(Doc::text(name.to_string()));
+    }
+
+    // TODO: oq3_syntax's Param::name() always returns None.
+    // Workaround: use syntax text directly.
+    if let Some(params) = g.angle_params() {
+        let param_text = params.syntax().text().to_string();
+        if !param_text.trim().is_empty() && param_text != "()" {
+            parts.push(Doc::text(param_text));
+        }
+    }
+
+    if let Some(qubits) = g.qubit_params() {
+        let qubit_text = qubits.syntax().text().to_string();
+        if !qubit_text.trim().is_empty() {
+            parts.push(Doc::space());
+            parts.push(Doc::text(qubit_text));
+        }
+    }
+
+    parts.push(Doc::text(" {"));
+    if let Some(body) = g.body() {
+        parts.push(Doc::indent(Doc::concat(vec![
+            Doc::hardline(),
+            format_gate_body(ctx, body),
+        ])));
+        parts.push(Doc::hardline());
+    }
+    parts.push(Doc::text("}"));
+
+    Doc::concat(parts)
+}
+
+fn format_gate_body(ctx: &FormatContext, body: ast::BlockExpr) -> Doc {
+    let stmts: Vec<Doc> = body
+        .statements()
+        .map(|stmt| format_stmt(ctx, stmt))
+        .collect();
+    join(stmts, Doc::hardline())
+}
+
+fn format_measure_expr(m: ast::MeasureExpression) -> Doc {
+    let mut parts = vec![Doc::text("measure ")];
+
+    if let Some(qubit) = m.gate_operand() {
+        parts.push(format_gate_operand(qubit));
+    }
+
+    Doc::concat(parts)
+}
+
+fn format_measure_stmt(m: ast::Measure) -> Doc {
+    Doc::text(m.syntax().text().to_string().trim())
+}
+
+fn format_reset(r: ast::Reset) -> Doc {
+    let mut parts = vec![Doc::text("reset ")];
+
+    if let Some(qubit) = r.gate_operand() {
+        parts.push(format_gate_operand(qubit));
+    }
+
+    parts.push(Doc::text(";"));
+    Doc::concat(parts)
+}
+
+fn format_barrier(b: ast::Barrier) -> Doc {
+    let mut parts = vec![Doc::text("barrier")];
+
+    if let Some(qubit_list) = b.qubit_list() {
+        let qubits: Vec<_> = qubit_list.gate_operands().collect();
+        if !qubits.is_empty() {
+            parts.push(Doc::space());
+            let qubit_docs: Vec<Doc> = qubits.into_iter().map(format_gate_operand).collect();
+            parts.push(join(qubit_docs, Doc::text(", ")));
+        }
+    }
+
+    parts.push(Doc::text(";"));
+    Doc::concat(parts)
+}
+
+fn format_assignment(a: ast::AssignmentStmt) -> Doc {
+    Doc::text(a.syntax().text().to_string().trim())
+}
+
+fn format_classical_decl(c: ast::ClassicalDeclarationStatement) -> Doc {
+    let mut parts = vec![];
+
+    if let Some(scalar_type) = c.scalar_type() {
+        parts.push(Doc::text(scalar_type.syntax().text().to_string()));
+    } else if let Some(array_type) = c.array_type() {
+        parts.push(Doc::text(array_type.syntax().text().to_string()));
+    }
+
+    parts.push(Doc::space());
+
+    if let Some(name) = c.name() {
+        parts.push(Doc::text(name.to_string()));
+    }
+
+    if let Some(init) = c.expr() {
+        parts.push(Doc::text(" = "));
+        parts.push(format_expr(init));
+    }
+
+    parts.push(Doc::text(";"));
+    Doc::concat(parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fmt(source: &str) -> String {
+        let config = FormatConfig::default();
+        format_source(source, &config).unwrap()
+    }
+
+    #[test]
+    fn test_version() {
+        let result = fmt("OPENQASM  3.0;");
+        assert_eq!(result.trim(), "OPENQASM 3.0;");
+    }
+
+    #[test]
+    fn test_qubit_decl() {
+        let result = fmt("qubit[2] q;");
+        assert_eq!(result.trim(), "qubit[2] q;");
+    }
+
+    #[test]
+    fn test_gate_call() {
+        let result = fmt("h q[0];");
+        assert_eq!(result.trim(), "h q[0];");
+    }
+
+    #[test]
+    fn test_cx_gate() {
+        let result = fmt("cx q[0], q[1];");
+        assert_eq!(result.trim(), "cx q[0], q[1];");
+    }
+
+    #[test]
+    fn test_gate_def() {
+        let input = "gate mygate(theta) q { rz(theta) q; }";
+        let result = fmt(input);
+        assert!(result.contains("gate mygate(theta) q {"));
+        assert!(result.contains("rz(theta) q;"));
+    }
+}

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -10,7 +10,7 @@ pub enum Doc {
 }
 
 impl Doc {
-    pub fn nil() -> Slef {
+    pub fn nil() -> Self {
         Doc::Nil
     }
 
@@ -33,7 +33,7 @@ impl Doc {
     pub fn concat(docs: Vec<Doc>) -> Self {
         let docs: Vec<_> = docs
             .into_iter()
-            .filter(|d| !matches!(d, Doc::Nill))
+            .filter(|d| !matches!(d, Doc::Nil))
             .collect();
         match docs.len() {
             0 => Doc::Nil,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,19 @@
+//! OpenQASM 3.0 formatter
+
+pub mod comment;
 pub mod config;
 pub mod error;
+pub mod format;
+pub mod ir;
+pub mod printer;
 
-pub fn format(source: &str) -> Result<String, error::FormatError> {
-    Ok(source.to_string())
+pub use config::FormatConfig;
+pub use error::FormatError;
+
+pub fn format(source: &str) -> Result<String, FormatError> {
+    format_with_config(source, FormatConfig::default())
+}
+
+pub fn format_with_config(source: &str, config: FormatConfig) -> Result<String, FormatError> {
+    format::format_source(source, &config)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,125 @@
+use std::fs;
+use std::io::{self, Read};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+
+use qasmfmt::{FormatConfig, format_with_config};
+
+#[derive(Parser)]
+#[command(name = "qasmfmt")]
+#[command(author, version, about = "OpenQASM 3.0 formatter", long_about = None)]
+struct Cli {
+    #[arg(value_name = "FILE")]
+    files: Vec<PathBuf>,
+
+    #[arg(short, long)]
+    write: bool,
+
+    #[arg(short, long)]
+    check: bool,
+
+    #[arg(short, long)]
+    diff: bool,
+
+    #[arg(short, long, default_value = "4")]
+    indent: usize,
+
+    #[arg(long, default_value = "100")]
+    max_width: usize,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    let config = FormatConfig {
+        indent_size: cli.indent,
+        max_width: cli.max_width,
+        ..Default::default()
+    };
+
+    if cli.files.is_empty() {
+        format_stdin(&config)
+    } else {
+        let mut has_error = false;
+        for file in &cli.files {
+            if let Err(e) = format_file(file, &config, cli.write, cli.check, cli.diff) {
+                eprintln!("Error processing {}: {}", file.display(), e);
+                has_error = true;
+            }
+        }
+        if has_error {
+            std::process::exit(1);
+        }
+        Ok(())
+    }
+}
+
+fn format_stdin(config: &FormatConfig) -> Result<()> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+
+    let output = format_with_config(&input, config.clone()).context("Failed to format input")?;
+
+    print!("{}", output);
+    Ok(())
+}
+
+fn format_file(
+    path: &PathBuf,
+    config: &FormatConfig,
+    write: bool,
+    check: bool,
+    diff: bool,
+) -> Result<()> {
+    let input =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+
+    let output = format_with_config(&input, config.clone())
+        .with_context(|| format!("Failed to format {}", path.display()))?;
+
+    if check {
+        if input != output {
+            eprintln!("Would reformat: {}", path.display());
+            std::process::exit(1);
+        }
+    } else if diff {
+        print_diff(&input, &output, path);
+    } else if write {
+        fs::write(path, &output).with_context(|| format!("Failed to write {}", path.display()))?;
+        eprintln!("Formatted: {}", path.display());
+    } else {
+        print!("{}", output);
+    }
+
+    Ok(())
+}
+
+fn print_diff(original: &str, formatted: &str, path: &PathBuf) {
+    if original == formatted {
+        return;
+    }
+
+    println!("--- {}", path.display());
+    println!("+++ {}", path.display());
+
+    let orig_lines: Vec<&str> = original.lines().collect();
+    let fmt_lines: Vec<&str> = formatted.lines().collect();
+
+    let max_lines = orig_lines.len().max(fmt_lines.len());
+
+    for i in 0..max_lines {
+        let orig_line = orig_lines.get(i).copied().unwrap_or("");
+        let fmt_line = fmt_lines.get(i).copied().unwrap_or("");
+
+        if orig_line != fmt_line {
+            if i < orig_lines.len() {
+                println!("-{}: {}", i + 1, orig_line);
+            }
+            if i < fmt_lines.len() {
+                println!("+{}: {}", i + 1, fmt_line);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Added `qasmfmt` binary for command-line usage with options for writing, checking, and diffing formatted files.
- Introduced `Comment` and `CommentMap` structures for extracting comments from source code.
- Implemented formatting logic in `format.rs` to handle various OpenQASM statements and expressions.
- Enhanced `Printer` to manage indentation levels and line formatting.
- Fixed typos in `ir.rs` and improved error handling in formatting functions.
- Updated dependencies in `Cargo.toml` for necessary libraries.
